### PR TITLE
Add mcp-get installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,23 @@ A Model Context Protocol server that provides browser automation capabilities us
 ## Screenshot
 ![Playwright + Claude](image/playwright_claude.png)
 
-## Here is how you need to build the code in your local machine
+## Installation
+
+You can install the package using either npm or mcp-get:
+
+Using npm:
+```bash
+npm install -g @executeautomation/playwright-mcp-server
+```
+
+Using mcp-get:
+```bash
+npx @michaellatman/mcp-get@latest install @executeautomation/playwright-mcp-server
+```
+
+## Building from Source
+
+If you want to build the code from source:
 
 **Clone the repository**
 ```bash


### PR DESCRIPTION
Add mcp-get installation instructions

This PR adds installation instructions for using mcp-get to install the package, while preserving the existing npm installation method. Changes include:

- Added mcp-get installation command
- Preserved existing npm installation instructions
- Reorganized installation section for clarity
- Maintained existing documentation style

The package is properly published on npm and can be installed via both methods.