### PR TITLE
feat: add viewport size configuration

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,6 +9,10 @@ export function createToolDefinitions(): Tool[] {
         type: "object",
         properties: {
           url: { type: "string" },
+          width: { type: "number", description: "Viewport width in pixels (default: 1920)" },
+          height: { type: "number", description: "Viewport height in pixels (default: 1080)" },
+          timeout: { type: "number", description: "Navigation timeout in milliseconds" },
+          waitUntil: { type: "string", description: "Navigation wait condition" }
         },
         required: ["url"],
       },
@@ -158,7 +162,6 @@ export const BROWSER_TOOLS = [
   "playwright_hover",
   "playwright_evaluate"
 ];
-
 
 // API Request tools for conditional launch
 export const API_TOOLS = [

--- a/src/toolsHandler.ts
+++ b/src/toolsHandler.ts
@@ -12,11 +12,20 @@ const consoleLogs: string[] = [];
 const screenshots = new Map<string, string>();
 const defaultDownloadsPath = path.join(os.homedir(), 'Downloads');
 
-async function ensureBrowser() {
+// Viewport type definition
+type ViewportSize = {
+  width?: number;
+  height?: number;
+};
+
+async function ensureBrowser(viewport?: ViewportSize) {
   if (!browser) {
     browser = await chromium.launch({ headless: false });
     const context = await browser.newContext({
-      viewport: { width: 1920, height: 1080 },
+      viewport: {
+        width: viewport?.width ?? 1920,
+        height: viewport?.height ?? 1080,
+      },
       deviceScaleFactor: 1,
     });
 
@@ -51,7 +60,10 @@ export async function handleToolCall(
 
   // Only launch browser if the tool requires browser interaction
   if (requiresBrowser) {
-    page = await ensureBrowser();
+    page = await ensureBrowser({
+      width: args.width,
+      height: args.height
+    });
   }
 
   // Set up API context for API-related operations
@@ -70,7 +82,8 @@ export async function handleToolCall(
           toolResult: {
             content: [{
               type: "text",
-              text: `Navigated to ${args.url} with ${args.waitUntil || "load"} wait`,
+              text: `Navigated to ${args.url} with ${args.waitUntil || "load"} wait` +
+                    (args.width && args.height ? ` (viewport: ${args.width}x${args.height})` : ""),
             }],
             isError: false,
           },


### PR DESCRIPTION
This PR implements the viewport size configuration proposed in #24.

Changes:
- Add width/height parameters to playwright_navigate command
- Add timeout and waitUntil parameters for better navigation control
- Update response message to show viewport size when specified
- Default values remain at 1920x1080 for backward compatibility

Example:
```typescript
await playwright_navigate({
  url: "https://example.com",
  width: 375,
  height: 667,
  waitUntil: "networkidle"
});
```