### PR TITLE
fix: savePng, use sane viewport default

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,8 +9,8 @@ export function createToolDefinitions(): Tool[] {
         type: "object",
         properties: {
           url: { type: "string" },
-          width: { type: "number", description: "Viewport width in pixels (default: 1920)" },
-          height: { type: "number", description: "Viewport height in pixels (default: 1080)" },
+          width: { type: "number", description: "Viewport width in pixels (default: 1280)" },
+          height: { type: "number", description: "Viewport height in pixels (default: 720)" },
           timeout: { type: "number", description: "Navigation timeout in milliseconds" },
           waitUntil: { type: "string", description: "Navigation wait condition" }
         },

--- a/src/toolsHandler.ts
+++ b/src/toolsHandler.ts
@@ -23,8 +23,8 @@ async function ensureBrowser(viewport?: ViewportSize) {
     browser = await chromium.launch({ headless: false });
     const context = await browser.newContext({
       viewport: {
-        width: viewport?.width ?? 1920,
-        height: viewport?.height ?? 1080,
+        width: viewport?.width ?? 1280,
+        height: viewport?.height ?? 720,
       },
       deviceScaleFactor: 1,
     });
@@ -127,7 +127,7 @@ export async function handleToolCall(
         const responseContent: (TextContent | ImageContent)[] = [];
 
         // Handle PNG file saving
-        if (args.savePng !== false) {
+        if (args.savePng === true) {
           const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
           const filename = `${args.name}-${timestamp}.png`;
           const downloadsDir = args.downloadsDir || defaultDownloadsPath;


### PR DESCRIPTION
Fix a bug where the files were always downloaded even when `savePng` was unset, essentially making it defaulting to `true` instead of `false` 
Additionally, use sane default for the viewport, on macOS `1920x1080` is bigger than the default screen size (`1512x982`). Default to `1280x720` instead, which is the [official playwright default](https://playwright.dev/docs/api/class-browser#browser-new-context-option-viewport)