### PR TITLE
feat: playwright_iframe_click

### DIFF
--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -56,6 +56,17 @@ Click elements on the page.
 
 ---
 
+### Playwright_iframe_click
+Click elements in an iframe on the page.
+
+- **`iframeSelector`** *(string)*:  
+  CSS selector for the iframe containing the element to click.
+
+- **`selector`** *(string)*:  
+  CSS selector for the element to click.
+
+---
+
 ### Playwright_hover
 Hover over elements on the page.
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,6 @@
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
-export function createToolDefinitions(): Tool[] {
+export function createToolDefinitions() {
   return [
     {
       name: "playwright_navigate",
@@ -40,9 +40,21 @@ export function createToolDefinitions(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          selector: { type: "string", description: "CSS selector for element to click" },
+          selector: { type: "string", description: "CSS selector for the element to click" },
         },
         required: ["selector"],
+      },
+    },
+    {
+      name: "playwright_iframe_click",
+      description: "Click an element in an iframe on the page",
+      inputSchema: {
+        type: "object",
+        properties: {
+          iframeSelector: { type: "string", description: "CSS selector for the iframe containing the element to click" },
+          selector: { type: "string", description: "CSS selector for the element to click" },
+        },
+        required: ["iframeSelector", "selector"],
       },
     },
     {
@@ -149,7 +161,7 @@ export function createToolDefinitions(): Tool[] {
         required: ["url"],
       },
     },
-  ];
+  ] as const satisfies Tool[];
 }
 
 // Browser-requiring tools for conditional browser launch
@@ -157,6 +169,7 @@ export const BROWSER_TOOLS = [
   "playwright_navigate",
   "playwright_screenshot",
   "playwright_click",
+  "playwright_iframe_click",
   "playwright_fill",
   "playwright_select",
   "playwright_hover",

--- a/src/toolsHandler.ts
+++ b/src/toolsHandler.ts
@@ -1,9 +1,9 @@
-import { chromium, Browser, Page, request, APIRequestContext } from "playwright";
-import { CallToolResult, TextContent, ImageContent } from "@modelcontextprotocol/sdk/types.js";
-import { BROWSER_TOOLS, API_TOOLS } from "./tools.js";
+import type { CallToolResult, ImageContent, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import fs from 'node:fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { APIRequestContext, Browser, chromium, Page, request } from 'playwright';
+import { API_TOOLS, BROWSER_TOOLS } from './tools.js';
 
 // Global state
 let browser: Browser | undefined;
@@ -188,6 +188,27 @@ export async function handleToolCall(
           content: [{
             type: "text",
             text: `Failed to click ${args.selector}: ${(error as Error).message}`,
+          }],
+          isError: true,
+        };
+      }
+
+    case "playwright_iframe_click":
+      try {
+        const iframe = page!.frameLocator(args.iframeSelector);
+        await iframe.locator(args.selector).click();
+        return {
+          content: [{
+            type: "text",
+            text: `Clicked: ${args.selector} (iframe: ${args.iframeSelector})`,
+          }],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text",
+            text: `Failed to click ${args.selector} in iframe ${args.iframeSelector}: ${(error as Error).message}`,
           }],
           isError: true,
         };


### PR DESCRIPTION
Hi there 👋🏼 

Thanks for this great work!

I came across a use case where I want Playwright to click an element in an iframe.

As it requires a specific syntax (i.e. using Page's #`frameLocator`) to interact with the content of the iframe, I wanted to propose a new "browser tool" in the MCP server.

I basically reused the `playwright_click` approach and made the required changes so it works with an iframe.

My prompt is (using Codestral):

> Using MCP Playwright: 
> Navigate to the `/preview` route of my app.
> Then click on the button "Load".
> 
> This will load new content in the only iframe of the document. From now on, all operations and assertions happen in this iframe.
> 
> Click on the button "Add Funds" in the iframe.
> Assert that a "Loading" element (`div.loading-spinner`) has been created inside the iframe.
> 
> Then click again on the button "Add Funds" in the iframe. 
> Assert that the "Loading" element (`div.loading-spinner`) has disappeared from the iframe.

The tool is invoked as expected:

<img width="721" alt="image" src="https://github.com/user-attachments/assets/a31acc3e-5c68-497e-90c0-47788e1aec4c" />

And the task finally succeeded ✅

Any feedback is most welcome, I'd be glad to improve this first iteration.
