### PR TITLE
feat: wait for HTTP response; feat: custom user agent

### DIFF
--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -165,3 +165,12 @@ Wait for and validate a previously initiated HTTP response wait operation.
     Full URL of the captured response.
   - **`responseBody`** *(string)*:  
     Full response body in JSON format.
+
+---
+
+### playwright_custom_user_agent
+Set a custom User Agent for the browser.
+
+- **Inputs:**
+  - **`userAgent`** *(string)*:  
+    Custom User Agent for the Playwright browser instance

--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -136,5 +136,32 @@ Supports Retrieval of logs like - all, error, warning, log, info, debug
   Close the browser and release all resources.
   Useful while working with Cline, Cursor to release the resources.
 
+---
 
+### Playwright_expect_response
+Ask Playwright to start waiting for a HTTP response. This tool initiates the wait operation but does not wait for its completion.
 
+- **Inputs:**
+  - **`id`** *(string)*:  
+    Unique & arbitrary identifier to be used for retrieving this response later with `Playwright_assert_response`.
+  - **`url`** *(string)*:  
+    URL pattern to match in the response.
+
+---
+
+### Playwright_assert_response
+Wait for and validate a previously initiated HTTP response wait operation.
+
+- **Inputs:**
+  - **`id`** *(string)*:  
+    Identifier of the HTTP response initially expected using `Playwright_expect_response`.
+  - **`value`** *(string, optional)*:  
+    Data to expect in the body of the HTTP response. If provided, the assertion will fail if this value is not found in the response body.
+
+- **Response:**
+  - **`statusCode`** *(string)*:  
+    Status code of the response.
+  - **`responseUrl`** *(string)*:  
+    Full URL of the captured response.
+  - **`responseBody`** *(string)*:  
+    Full response body in JSON format.

--- a/src/__tests__/__snapshots__/tools.test.ts.snap
+++ b/src/__tests__/__snapshots__/tools.test.ts.snap
@@ -326,5 +326,46 @@ exports[`Tool Definitions should match snapshot 1`] = `
     },
     "name": "playwright_delete",
   },
+  {
+    "description": "Ask Playwright to start waiting for a HTTP response. This tool initiates the wait operation but does not wait for its completion.",
+    "inputSchema": {
+      "properties": {
+        "id": {
+          "description": "Unique & arbitrary identifier to be used for retrieving this response later with \`Playwright_assert_response\`.",
+          "type": "string",
+        },
+        "url": {
+          "description": "URL pattern to match in the response.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "url",
+      ],
+      "type": "object",
+    },
+    "name": "playwright_expect_response",
+  },
+  {
+    "description": "Wait for and validate a previously initiated HTTP response wait operation.",
+    "inputSchema": {
+      "properties": {
+        "id": {
+          "description": "Identifier of the HTTP response initially expected using \`Playwright_expect_response\`.",
+          "type": "string",
+        },
+        "value": {
+          "description": "Data to expect in the body of the HTTP response. If provided, the assertion will fail if this value is not found in the response body.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+      ],
+      "type": "object",
+    },
+    "name": "playwright_assert_response",
+  },
 ]
 `;

--- a/src/__tests__/__snapshots__/tools.test.ts.snap
+++ b/src/__tests__/__snapshots__/tools.test.ts.snap
@@ -367,5 +367,21 @@ exports[`Tool Definitions should match snapshot 1`] = `
     },
     "name": "playwright_assert_response",
   },
+  {
+    "description": "Set a custom User Agent for the browser",
+    "inputSchema": {
+      "properties": {
+        "userAgent": {
+          "description": "Custom User Agent for the Playwright browser instance",
+          "type": "string",
+        },
+      },
+      "required": [
+        "userAgent",
+      ],
+      "type": "object",
+    },
+    "name": "playwright_custom_user_agent",
+  },
 ]
 `;

--- a/src/toolHandler.ts
+++ b/src/toolHandler.ts
@@ -6,7 +6,9 @@ import {
   ScreenshotTool,
   NavigationTool,
   CloseBrowserTool,
-  ConsoleLogsTool
+  ConsoleLogsTool,
+  ExpectResponseTool,
+  AssertResponseTool,
 } from './tools/browser/index.js';
 import {
   ClickTool,
@@ -39,6 +41,8 @@ let fillTool: FillTool;
 let selectTool: SelectTool;
 let hoverTool: HoverTool;
 let evaluateTool: EvaluateTool;
+let expectResponseTool: ExpectResponseTool;
+let assertResponseTool: AssertResponseTool;
 let getRequestTool: GetRequestTool;
 let postRequestTool: PostRequestTool;
 let putRequestTool: PutRequestTool;
@@ -95,6 +99,8 @@ function initializeTools(server: any) {
   if (!selectTool) selectTool = new SelectTool(server);
   if (!hoverTool) hoverTool = new HoverTool(server);
   if (!evaluateTool) evaluateTool = new EvaluateTool(server);
+  if (!expectResponseTool) expectResponseTool = new ExpectResponseTool(server);
+  if (!assertResponseTool) assertResponseTool = new AssertResponseTool(server);
   
   // API tools
   if (!getRequestTool) getRequestTool = new GetRequestTool(server);
@@ -166,6 +172,12 @@ export async function handleToolCall(
       
     case "playwright_evaluate":
       return await evaluateTool.execute(args, context);
+
+    case "playwright_expect_response":
+      return await expectResponseTool.execute(args, context);
+
+    case "playwright_assert_response":
+      return await assertResponseTool.execute(args, context);
       
     // API tools
     case "playwright_get":

--- a/src/toolHandler.ts
+++ b/src/toolHandler.ts
@@ -1,7 +1,8 @@
-import { Browser, Page, chromium, request } from 'playwright';
+import type { Browser, Page } from 'playwright';
+import { chromium, request } from 'playwright';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { BROWSER_TOOLS, API_TOOLS } from './tools.js';
-import { ToolContext } from './tools/common/types.js';
+import type { ToolContext } from './tools/common/types.js';
 import { 
   ScreenshotTool,
   NavigationTool,
@@ -9,6 +10,7 @@ import {
   ConsoleLogsTool,
   ExpectResponseTool,
   AssertResponseTool,
+  CustomUserAgentTool
 } from './tools/browser/index.js';
 import {
   ClickTool,
@@ -43,19 +45,30 @@ let hoverTool: HoverTool;
 let evaluateTool: EvaluateTool;
 let expectResponseTool: ExpectResponseTool;
 let assertResponseTool: AssertResponseTool;
+let customUserAgentTool: CustomUserAgentTool;
 let getRequestTool: GetRequestTool;
 let postRequestTool: PostRequestTool;
 let putRequestTool: PutRequestTool;
 let patchRequestTool: PatchRequestTool;
 let deleteRequestTool: DeleteRequestTool;
 
+interface BrowserSettings {
+  viewport?: {
+    width?: number;
+    height?: number;
+  };
+  userAgent?: string;
+}
+
 /**
  * Ensures a browser is launched and returns the page
  */
-async function ensureBrowser(viewport?: { width?: number; height?: number }) {
+async function ensureBrowser(browserSettings?: BrowserSettings) {
   if (!browser) {
+    const { viewport, userAgent } = browserSettings ?? {};
     browser = await chromium.launch({ headless: false });
     const context = await browser.newContext({
+      ...userAgent && { userAgent },
       viewport: {
         width: viewport?.width ?? 1280,
         height: viewport?.height ?? 720,
@@ -101,6 +114,7 @@ function initializeTools(server: any) {
   if (!evaluateTool) evaluateTool = new EvaluateTool(server);
   if (!expectResponseTool) expectResponseTool = new ExpectResponseTool(server);
   if (!assertResponseTool) assertResponseTool = new AssertResponseTool(server);
+  if (!customUserAgentTool) customUserAgentTool = new CustomUserAgentTool(server);
   
   // API tools
   if (!getRequestTool) getRequestTool = new GetRequestTool(server);
@@ -128,10 +142,14 @@ export async function handleToolCall(
   
   // Set up browser if needed
   if (BROWSER_TOOLS.includes(name)) {
-    context.page = await ensureBrowser({
-      width: args.width,
-      height: args.height
-    });
+    const browserSettings = {
+      viewport: {
+        width: args.width,
+        height: args.height
+      },
+      userAgent: name === "playwright_custom_user_agent" ? args.userAgent : undefined
+    };
+    context.page = await ensureBrowser(browserSettings);
     context.browser = browser;
   }
 
@@ -178,6 +196,9 @@ export async function handleToolCall(
 
     case "playwright_assert_response":
       return await assertResponseTool.execute(args, context);
+
+    case "playwright_custom_user_agent":
+      return await customUserAgentTool.execute(args, context);
       
     // API tools
     case "playwright_get":

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -222,6 +222,17 @@ export function createToolDefinitions() {
         required: ["id"],
       },
     },
+    {
+      name: "playwright_custom_user_agent",
+      description: "Set a custom User Agent for the browser",
+      inputSchema: {
+        type: "object",
+        properties: {
+          userAgent: { type: "string", description: "Custom User Agent for the Playwright browser instance" }
+        },
+        required: ["userAgent"],
+      },
+    },
   ] as const satisfies Tool[];
 }
 
@@ -237,7 +248,8 @@ export const BROWSER_TOOLS = [
   "playwright_evaluate",
   "playwright_close",
   "playwright_expect_response",
-  "playwright_assert_response"
+  "playwright_assert_response",
+  "playwright_custom_user_agent",
 ];
 
 // API Request tools for conditional launch

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -198,6 +198,30 @@ export function createToolDefinitions() {
         required: ["url"],
       },
     },
+    {
+      name: "playwright_expect_response",
+      description: "Ask Playwright to start waiting for a HTTP response. This tool initiates the wait operation but does not wait for its completion.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Unique & arbitrary identifier to be used for retrieving this response later with `Playwright_assert_response`." },
+          url: { type: "string", description: "URL pattern to match in the response." }
+        },
+        required: ["id", "url"],
+      },
+    },
+    {
+      name: "playwright_assert_response",
+      description: "Wait for and validate a previously initiated HTTP response wait operation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Identifier of the HTTP response initially expected using `Playwright_expect_response`." },
+          value: { type: "string", description: "Data to expect in the body of the HTTP response. If provided, the assertion will fail if this value is not found in the response body." }
+        },
+        required: ["id"],
+      },
+    },
   ] as const satisfies Tool[];
 }
 
@@ -211,7 +235,9 @@ export const BROWSER_TOOLS = [
   "playwright_select",
   "playwright_hover",
   "playwright_evaluate",
-  "playwright_close"
+  "playwright_close",
+  "playwright_expect_response",
+  "playwright_assert_response"
 ];
 
 // API Request tools for conditional launch

--- a/src/tools/browser/index.ts
+++ b/src/tools/browser/index.ts
@@ -4,6 +4,7 @@ export * from './navigation.js';
 export * from './console.js';
 export * from './interaction.js';
 export * from './response.js';
+export * from './useragent.js';
 
 // TODO: Add exports for other browser tools as they are implemented
 // export * from './interaction.js'; 

--- a/src/tools/browser/index.ts
+++ b/src/tools/browser/index.ts
@@ -3,6 +3,7 @@ export * from './screenshot.js';
 export * from './navigation.js';
 export * from './console.js';
 export * from './interaction.js';
+export * from './response.js';
 
 // TODO: Add exports for other browser tools as they are implemented
 // export * from './interaction.js'; 

--- a/src/tools/browser/response.ts
+++ b/src/tools/browser/response.ts
@@ -1,0 +1,86 @@
+import type { Response } from 'playwright';
+import { BrowserToolBase } from './base.js';
+import type { ToolContext, ToolResponse } from '../common/types.js';
+import { createSuccessResponse, createErrorResponse } from '../common/types.js';
+
+const responsePromises = new Map<string, Promise<Response>>();
+
+interface ExpectResponseArgs {
+  id: string;
+  url: string;
+}
+
+interface AssertResponseArgs {
+  id: string;
+  value?: string;
+}
+
+/**
+ * Tool for setting up response wait operations
+ */
+export class ExpectResponseTool extends BrowserToolBase {
+  /**
+   * Execute the expect response tool
+   */
+  async execute(args: ExpectResponseArgs, context: ToolContext): Promise<ToolResponse> {
+    return this.safeExecute(context, async (page) => {
+      if (!args.id || !args.url) {
+        return createErrorResponse("Missing required parameters: id and url must be provided");
+      }
+
+      const responsePromise = page.waitForResponse(args.url);
+      responsePromises.set(args.id, responsePromise);
+
+      return createSuccessResponse(`Started waiting for response with ID ${args.id}`);
+    });
+  }
+}
+
+/**
+ * Tool for asserting and validating responses
+ */
+export class AssertResponseTool extends BrowserToolBase {
+  /**
+   * Execute the assert response tool
+   */
+  async execute(args: AssertResponseArgs, context: ToolContext): Promise<ToolResponse> {
+    return this.safeExecute(context, async () => {
+      if (!args.id) {
+        return createErrorResponse("Missing required parameter: id must be provided");
+      }
+
+      const responsePromise = responsePromises.get(args.id);
+      if (!responsePromise) {
+        return createErrorResponse(`No response wait operation found with ID: ${args.id}`);
+      }
+
+      try {
+        const response = await responsePromise;
+        const body = await response.json();
+
+        if (args.value) {
+          const bodyStr = JSON.stringify(body);
+          if (!bodyStr.includes(args.value)) {
+            const messages = [
+              `Response body does not contain expected value: ${args.value}`,
+              `Actual body: ${bodyStr}`
+            ];
+            return createErrorResponse(messages.join('\n'));
+          }
+        }
+
+        const messages = [
+          `Response assertion for ID ${args.id} successful`,
+          `URL: ${response.url()}`,
+          `Status: ${response.status()}`,
+          `Body: ${JSON.stringify(body, null, 2)}`
+        ];
+        return createSuccessResponse(messages.join('\n'));
+      } catch (error) {
+        return createErrorResponse(`Failed to assert response: ${(error as Error).message}`);
+      } finally {
+        responsePromises.delete(args.id);
+      }
+    });
+  }
+} 

--- a/src/tools/browser/useragent.ts
+++ b/src/tools/browser/useragent.ts
@@ -1,0 +1,40 @@
+import { BrowserToolBase } from './base.js';
+import type { ToolContext, ToolResponse } from '../common/types.js';
+import { createSuccessResponse, createErrorResponse } from '../common/types.js';
+
+interface CustomUserAgentArgs {
+  userAgent: string;
+}
+
+/**
+ * Tool for validating custom User Agent settings
+ */
+export class CustomUserAgentTool extends BrowserToolBase {
+  /**
+   * Execute the custom user agent tool
+   */
+  async execute(args: CustomUserAgentArgs, context: ToolContext): Promise<ToolResponse> {
+    return this.safeExecute(context, async (page) => {
+      if (!args.userAgent) {
+        return createErrorResponse("Missing required parameter: userAgent must be provided");
+      }
+
+      try {
+        const currentUserAgent = await page.evaluate(() => navigator.userAgent);
+        
+        if (currentUserAgent !== args.userAgent) {
+          const messages = [
+            "Page was already initialized with a different User Agent.",
+            `Requested: ${args.userAgent}`,
+            `Current: ${currentUserAgent}`
+          ];
+          return createErrorResponse(messages.join('\n'));
+        }
+
+        return createSuccessResponse("User Agent validation successful");
+      } catch (error) {
+        return createErrorResponse(`Failed to validate User Agent: ${(error as Error).message}`);
+      }
+    });
+  }
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strictNullChecks": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
Hi guys 👋🏼 

Second PR for me here! I would like to see this feature in this (very helpful) MCP server.

Browser tools:
- `playwright_except_response`
- `playwright_assert_response`

The idea is to reproduce the Playwright's `page` `waitForResponse` asynchronous operation:

```ts
// Start waiting for response before clicking. Note no await.
const responsePromise = page.waitForResponse('https://example.com/resource');

await page.getByText('trigger response').click();

const response = await responsePromise;
```

Here's what I'm doing in my Gherkin-style test, which is then executed by Cursor (using the MCP server):

<img width="298" alt="image" src="https://github.com/user-attachments/assets/2648bab5-1ed4-4412-9ca6-a472879d7c55" />


```gherkin
  Scenario: Logging in requires captcha verification
    Given I expect the browser to receive an HTTP response from "**/security/captcha-precheck"
    When I enter "some-identifier@test.com" in the input and I submit
    Then The browser should have received the HTTP response
    And Its body should contain a property "captchaFamily"
```

It works very well on my side.
I don't need to provide an `id` as the Agent is generating one. But I do think that it's useful, just in case we potentially have multiple response to handle. I did try by writing `an HTTP response (id : "captcha-response-1")` (expect) and `the HTTP response (id : "captcha-response-1")` (assert) ✅ 

___

Second step: 

A new tool `playwright_custom_user_agent` to define a custom user agent. 
**It must run before any other browser operation in order to work**. As the User Agent cannot be changed dynamically using the Context nor the Page... Otherwise it means creating a new Context (hence, creating a new Page).

```gherkin
Feature: Signing into your account
  Background:
    Given I use a custom User Agent "my-robot-agent"
    And I navigate to https://my-website.com/login
```

<img width="325" alt="image" src="https://github.com/user-attachments/assets/44eb7954-7bb3-4782-8d99-64a1a4ba7429" />
