### PR TITLE
Exit process on host close

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,4 +30,7 @@ async function runServer() {
   await server.connect(transport);
 }
 
-runServer().catch(console.error);
+runServer().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});


### PR DESCRIPTION
Hey!

Thank you for this awesome server!

I fixed a bug that keeps `mcp-playwright` server running after MCP host closes.

I noticed this bug in Cursor as MCP host. Every time I open new Cursor window, it starts new server, but it does not close on Cursor window close. As a result, there are many mcp-playwright servers up and running in my host machine:

![image](https://github.com/user-attachments/assets/d021bb63-3c4e-4575-8a8b-da43db92f772)

I see other MCP servers close on Cursor window close, such as [Github MCP Server](https://github.com/smithery-ai/reference-servers/tree/main/src/github)

