### PR TITLE
Added support for Firefox and WebKit

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -12,6 +12,7 @@ With the Playwright MCP server, you can:
 	- Enable LLMs to interact with web pages in a real browser environment.
 	- Perform tasks such as executing JavaScript, taking screenshots, and navigating web elements.
 	- Seamlessly handle API testing to validate endpoints and ensure reliability.
+	- Test across multiple browser engines including Chromium, Firefox, and WebKit.
 
 ![Playwright MCP Server](./img/mcp-server.png)
 

--- a/docs/docs/playwright-web/Examples.md
+++ b/docs/docs/playwright-web/Examples.md
@@ -5,6 +5,19 @@ sidebar_position: 4
 # 🌐 Examples of browser automation
 Lets see how we can use the power of Playwright MCP Server to automate our browser and do webscrapping
 
+### Using Different Browser Types
+
+Playwright MCP now supports multiple browser engines. You can choose between Chromium (default), Firefox, and WebKit:
+
+```bdd
+Given I navigate to website "https://example.com" using the "firefox" browser
+And I take a screenshot named "firefox-example"
+Then I navigate to website "https://example.com" using the "webkit" browser 
+And I take a screenshot named "webkit-example"
+```
+
+When you send these commands to Claude, it will open the website in Firefox first, take a screenshot, then switch to WebKit and take another screenshot, allowing you to compare how different browsers render the same website.
+
 ### Scenario in BDD Format
 ```bdd
 Given I navigate to website http://eaapp.somee.com and click login link

--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -30,6 +30,9 @@ Navigate to a URL in the browser with configurable viewport and browser settings
 - **`url`** *(string, required)*:  
   URL of the application under test.
 
+- **`browserType`** *(string, optional, default: "chromium")*:  
+  Browser engine to use. Supported values: "chromium", "firefox", "webkit".
+
 - **`width`** *(number, optional, default: 1280)*:  
   Viewport width in pixels.
 

--- a/docs/docs/release.mdx
+++ b/docs/docs/release.mdx
@@ -10,7 +10,6 @@ import YouTubeVideoEmbed from '@site/src/components/HomepageFeatures/YouTubeVide
   - New `browserType` parameter for `playwright_navigate` tool allows specifying browser engine 
   - Supported browser types: "chromium" (default), "firefox", and "webkit"
   - Seamless browser engine switching during automation sessions
-  - Added comprehensive [documentation on browser types](/docs/playwright-web/Browser-Types)
 - Enhanced test coverage for different browser engines
 - Updated documentation with browser-specific examples
 

--- a/docs/docs/release.mdx
+++ b/docs/docs/release.mdx
@@ -5,6 +5,15 @@ import YouTubeVideoEmbed from '@site/src/components/HomepageFeatures/YouTubeVide
 
 # Release Notes
 
+## Version 1.0.2
+- **Multi-Browser Support**: Added support for Firefox and WebKit browsers in addition to Chromium 🌐
+  - New `browserType` parameter for `playwright_navigate` tool allows specifying browser engine 
+  - Supported browser types: "chromium" (default), "firefox", and "webkit"
+  - Seamless browser engine switching during automation sessions
+  - Added comprehensive [documentation on browser types](/docs/playwright-web/Browser-Types)
+- Enhanced test coverage for different browser engines
+- Updated documentation with browser-specific examples
+
 ## Version 1.0.0
 - First major release of Playwright MCP Server with the tool structure changes 🚀
 - Fixed issue with headless mode in Playwright #62

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@executeautomation/playwright-mcp-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@executeautomation/playwright-mcp-server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.6.1",
         "@playwright/browser-chromium": "1.51.1",
+        "@playwright/browser-firefox": "1.51.1",
+        "@playwright/browser-webkit": "1.51.1",
         "playwright": "1.51.1"
       },
       "bin": {
@@ -880,6 +882,30 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.51.1.tgz",
       "integrity": "sha512-Xebxk0SrDKttd8VGiUwLxOMbuH/Lf/+vFyzFG7QHVvqsAOw3Ec7Xdl1HRB4dnVP/RTEytkH4OgQ4OFy6K2c1xw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/browser-firefox": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-firefox/-/browser-firefox-1.51.1.tgz",
+      "integrity": "sha512-F7RaES/0JtMafS5E4hdAWsvu01aalKOC6VSidklkoeDO5/duM3Ubl/C6eaBP+qHuwqZN/XGBxKHyYC3UoZwM8Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/browser-webkit": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-webkit/-/browser-webkit-1.51.1.tgz",
+      "integrity": "sha512-He51aydblwT1qx0IKI4hFgVlE7rQBayFaj5PQBLedrcDlMeoGOQsKVgqgo7/VsO7WHhDdJkkSuBoVXNyX7UodQ==",
       "hasInstallScript": true,
       "dependencies": {
         "playwright-core": "1.51.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executeautomation/playwright-mcp-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Model Context Protocol servers for Playwright",
   "license": "MIT",
   "author": "ExecuteAutomation, Ltd (https://executeautomation.com)",
@@ -29,6 +29,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.6.1",
     "@playwright/browser-chromium": "1.51.1",
+    "@playwright/browser-firefox": "1.51.1",
+    "@playwright/browser-webkit": "1.51.1",
     "playwright": "1.51.1"
   },
   "keywords": [

--- a/src/__tests__/toolHandler.test.ts
+++ b/src/__tests__/toolHandler.test.ts
@@ -1,5 +1,5 @@
 import { handleToolCall, getConsoleLogs, getScreenshots } from '../toolHandler.js';
-import { Browser, Page, chromium } from 'playwright';
+import { Browser, Page, chromium, firefox, webkit } from 'playwright';
 import { jest } from '@jest/globals';
 
 // Mock the Playwright browser and page
@@ -133,6 +133,12 @@ jest.mock('playwright', () => {
     chromium: {
       launch: mockLaunch
     },
+    firefox: {
+      launch: mockLaunch
+    },
+    webkit: {
+      launch: mockLaunch
+    },
     request: {
       newContext: mockNewApiContext
     },
@@ -178,6 +184,54 @@ describe('Tool Handler', () => {
     const clickResult = await handleToolCall('playwright_click', { selector: '#test-button' }, mockServer);
     expect(clickResult).toBeDefined();
     expect(clickResult.content).toBeDefined();
+  });
+  
+  test('handleToolCall should handle Firefox browser', async () => {
+    const navigateResult = await handleToolCall('playwright_navigate', { 
+      url: 'https://example.com',
+      browserType: 'firefox'
+    }, mockServer);
+    expect(navigateResult).toBeDefined();
+    expect(navigateResult.content).toBeDefined();
+    
+    // Verify browser state is reset
+    await handleToolCall('playwright_close', {}, mockServer);
+  });
+  
+  test('handleToolCall should handle WebKit browser', async () => {
+    const navigateResult = await handleToolCall('playwright_navigate', { 
+      url: 'https://example.com',
+      browserType: 'webkit'
+    }, mockServer);
+    expect(navigateResult).toBeDefined();
+    expect(navigateResult.content).toBeDefined();
+    
+    // Verify browser state is reset
+    await handleToolCall('playwright_close', {}, mockServer);
+  });
+  
+  test('handleToolCall should handle browser type switching', async () => {
+    // Start with default chromium
+    await handleToolCall('playwright_navigate', { url: 'https://example.com' }, mockServer);
+    
+    // Switch to Firefox
+    const firefoxResult = await handleToolCall('playwright_navigate', { 
+      url: 'https://firefox.com',
+      browserType: 'firefox'
+    }, mockServer);
+    expect(firefoxResult).toBeDefined();
+    expect(firefoxResult.content).toBeDefined();
+    
+    // Switch to WebKit
+    const webkitResult = await handleToolCall('playwright_navigate', { 
+      url: 'https://webkit.org',
+      browserType: 'webkit'
+    }, mockServer);
+    expect(webkitResult).toBeDefined();
+    expect(webkitResult.content).toBeDefined();
+    
+    // Clean up
+    await handleToolCall('playwright_close', {}, mockServer);
   });
   
   test('handleToolCall should handle API tools', async () => {

--- a/src/__tests__/tools/browser/navigation.test.ts
+++ b/src/__tests__/tools/browser/navigation.test.ts
@@ -55,6 +55,33 @@ describe('NavigationTool', () => {
     expect(result.content[0].text).toContain('Navigated to');
   });
 
+  test('should handle navigation with specific browser type', async () => {
+    const args = {
+      url: 'https://example.com',
+      waitUntil: 'networkidle',
+      browserType: 'firefox'
+    };
+
+    const result = await navigationTool.execute(args, mockContext);
+
+    expect(mockGoto).toHaveBeenCalledWith('https://example.com', { waitUntil: 'networkidle', timeout: 30000 });
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Navigated to');
+  });
+
+  test('should handle navigation with webkit browser type', async () => {
+    const args = {
+      url: 'https://example.com',
+      browserType: 'webkit'
+    };
+
+    const result = await navigationTool.execute(args, mockContext);
+
+    expect(mockGoto).toHaveBeenCalledWith('https://example.com', { waitUntil: 'load', timeout: 30000 });
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Navigated to');
+  });
+
   test('should handle navigation errors', async () => {
     const args = {
       url: 'https://example.com'

--- a/src/__tests__/tools/browser/screenshot.test.ts
+++ b/src/__tests__/tools/browser/screenshot.test.ts
@@ -161,4 +161,18 @@ describe('ScreenshotTool', () => {
     const screenshots = screenshotTool.getScreenshots();
     expect(screenshots.has('test-screenshot')).toBe(true);
   });
+
+  test('should take a screenshot with specific browser type', async () => {
+    const args = {
+      name: 'browser-type-test',
+      browserType: 'firefox'
+    };
+
+    // Execute with browser type
+    const result = await screenshotTool.execute(args, mockContext);
+    
+    expect(mockScreenshot).toHaveBeenCalled();
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Screenshot saved to');
+  });
 }); 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,6 +9,7 @@ export function createToolDefinitions() {
         type: "object",
         properties: {
           url: { type: "string", description: "URL to navigate to the website specified" },
+          browserType: { type: "string", description: "Browser type to use (chromium, firefox, webkit). Defaults to chromium", enum: ["chromium", "firefox", "webkit"] },
           width: { type: "number", description: "Viewport width in pixels (default: 1280)" },
           height: { type: "number", description: "Viewport height in pixels (default: 720)" },
           timeout: { type: "number", description: "Navigation timeout in milliseconds" },


### PR DESCRIPTION
- **Multi-Browser Support**: Added support for Firefox and WebKit browsers in addition to Chromium 🌐
  - New `browserType` parameter for `playwright_navigate` tool allows specifying browser engine 
  - Supported browser types: "chromium" (default), "firefox", and "webkit"
  - Seamless browser engine switching during automation sessions
- Enhanced test coverage for different browser engines
- Updated documentation with browser-specific examples
