### PR TITLE
feat: get text and html

### DIFF
--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -12,6 +12,7 @@ Playwright MCP for Browser automation has following key features
 - Screenshot capabilities
 - JavaScript execution
 - Basic web interaction (navigation, clicking, form filling, drop down select and hover)
+- Content retrieval (visible text and HTML)
 
 
 <YouTubeVideoEmbed videoId="8CcgFUE16HM" />
@@ -194,3 +195,22 @@ Set a custom User Agent for the browser.
 - **Inputs:**
   - **`userAgent`** *(string)*:  
     Custom User Agent for the Playwright browser instance
+
+---
+
+### playwright_get_visible_text
+Get the visible text content of the current page.
+
+- **Response:**
+  - **`content`** *(string)*:  
+    The visible text content of the current page, extracted from visible DOM elements.
+    Hidden elements (with display:none or visibility:hidden) are excluded.
+
+---
+
+### playwright_get_html
+Get the HTML content of the current page.
+
+- **Response:**
+  - **`content`** *(string)*:  
+    The complete HTML content of the current page.

--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -208,7 +208,7 @@ Get the visible text content of the current page.
 
 ---
 
-### playwright_get_html
+### playwright_get_visible_html
 Get the HTML content of the current page.
 
 - **Response:**

--- a/src/__tests__/tools/browser/visiblePage.test.ts
+++ b/src/__tests__/tools/browser/visiblePage.test.ts
@@ -1,0 +1,193 @@
+import { VisibleTextTool, VisibleHtmlTool } from '../../../tools/browser/visiblePage.js';
+import { ToolContext } from '../../../tools/common/types.js';
+import { Page, Browser } from 'playwright';
+import { jest } from '@jest/globals';
+
+// Mock the Page object
+const mockEvaluate = jest.fn();
+const mockContent = jest.fn();
+const mockIsClosed = jest.fn().mockReturnValue(false);
+
+const mockPage = {
+  evaluate: mockEvaluate,
+  content: mockContent,
+  isClosed: mockIsClosed
+} as unknown as Page;
+
+// Mock the browser
+const mockIsConnected = jest.fn().mockReturnValue(true);
+const mockBrowser = {
+  isConnected: mockIsConnected
+} as unknown as Browser;
+
+// Mock the server
+const mockServer = {
+  sendMessage: jest.fn()
+};
+
+// Mock context
+const mockContext = {
+  page: mockPage,
+  browser: mockBrowser,
+  server: mockServer
+} as ToolContext;
+
+describe('VisibleTextTool', () => {
+  let visibleTextTool: VisibleTextTool;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    visibleTextTool = new VisibleTextTool(mockServer);
+    // Reset mocks
+    mockIsConnected.mockReturnValue(true);
+    mockIsClosed.mockReturnValue(false);
+    mockEvaluate.mockImplementation(() => Promise.resolve('Sample visible text content'));
+  });
+
+  test('should retrieve visible text content', async () => {
+    const args = {};
+
+    const result = await visibleTextTool.execute(args, mockContext);
+
+    expect(mockEvaluate).toHaveBeenCalled();
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Visible text content');
+    expect(result.content[0].text).toContain('Sample visible text content');
+  });
+
+  test('should handle missing page', async () => {
+    const args = {};
+
+    // Context with browser but without page
+    const contextWithoutPage = {
+      browser: mockBrowser,
+      server: mockServer
+    } as unknown as ToolContext;
+
+    const result = await visibleTextTool.execute(args, contextWithoutPage);
+
+    expect(mockEvaluate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Page is not available');
+  });
+  
+  test('should handle disconnected browser', async () => {
+    const args = {};
+    
+    // Mock disconnected browser
+    mockIsConnected.mockReturnValueOnce(false);
+    
+    const result = await visibleTextTool.execute(args, mockContext);
+    
+    expect(mockEvaluate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Browser is not connected');
+  });
+  
+  test('should handle closed page', async () => {
+    const args = {};
+    
+    // Mock closed page
+    mockIsClosed.mockReturnValueOnce(true);
+    
+    const result = await visibleTextTool.execute(args, mockContext);
+    
+    expect(mockEvaluate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Page is not available or has been closed');
+  });
+
+  test('should handle evaluation errors', async () => {
+    const args = {};
+
+    // Mock evaluation error
+    mockEvaluate.mockImplementationOnce(() => Promise.reject(new Error('Evaluation failed')));
+
+    const result = await visibleTextTool.execute(args, mockContext);
+
+    expect(mockEvaluate).toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Failed to get visible text content');
+    expect(result.content[0].text).toContain('Evaluation failed');
+  });
+});
+
+describe('VisibleHtmlTool', () => {
+  let visibleHtmlTool: VisibleHtmlTool;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    visibleHtmlTool = new VisibleHtmlTool(mockServer);
+    // Reset mocks
+    mockIsConnected.mockReturnValue(true);
+    mockIsClosed.mockReturnValue(false);
+    mockContent.mockImplementation(() => Promise.resolve('<html><body>Sample HTML content</body></html>'));
+  });
+
+  test('should retrieve HTML content', async () => {
+    const args = {};
+
+    const result = await visibleHtmlTool.execute(args, mockContext);
+
+    expect(mockContent).toHaveBeenCalled();
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('HTML content');
+    expect(result.content[0].text).toContain('<html><body>Sample HTML content</body></html>');
+  });
+
+  test('should handle missing page', async () => {
+    const args = {};
+
+    // Context with browser but without page
+    const contextWithoutPage = {
+      browser: mockBrowser,
+      server: mockServer
+    } as unknown as ToolContext;
+
+    const result = await visibleHtmlTool.execute(args, contextWithoutPage);
+
+    expect(mockContent).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Page is not available');
+  });
+  
+  test('should handle disconnected browser', async () => {
+    const args = {};
+    
+    // Mock disconnected browser
+    mockIsConnected.mockReturnValueOnce(false);
+    
+    const result = await visibleHtmlTool.execute(args, mockContext);
+    
+    expect(mockContent).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Browser is not connected');
+  });
+  
+  test('should handle closed page', async () => {
+    const args = {};
+    
+    // Mock closed page
+    mockIsClosed.mockReturnValueOnce(true);
+    
+    const result = await visibleHtmlTool.execute(args, mockContext);
+    
+    expect(mockContent).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Page is not available or has been closed');
+  });
+
+  test('should handle content retrieval errors', async () => {
+    const args = {};
+
+    // Mock content error
+    mockContent.mockImplementationOnce(() => Promise.reject(new Error('Content retrieval failed')));
+
+    const result = await visibleHtmlTool.execute(args, mockContext);
+
+    expect(mockContent).toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Failed to get visible HTML content');
+    expect(result.content[0].text).toContain('Content retrieval failed');
+  });
+});

--- a/src/toolHandler.ts
+++ b/src/toolHandler.ts
@@ -414,10 +414,10 @@ export async function handleToolCall(
       case "playwright_custom_user_agent":
         return await customUserAgentTool.execute(args, context);
         
-      case "playwright_visible_text":
+      case "playwright_get_visible_text":
         return await visibleTextTool.execute(args, context);
       
-      case "playwright_visible_html":
+      case "playwright_get_visible_html":
         return await visibleHtmlTool.execute(args, context);
         
       // API tools

--- a/src/toolHandler.ts
+++ b/src/toolHandler.ts
@@ -20,6 +20,10 @@ import {
   HoverTool,
   EvaluateTool
 } from './tools/browser/interaction.js';
+import { 
+  VisibleTextTool, 
+  VisibleHtmlTool 
+} from './tools/browser/visiblePage.js';
 import {
   GetRequestTool,
   PostRequestTool,
@@ -27,6 +31,7 @@ import {
   PatchRequestTool,
   DeleteRequestTool
 } from './tools/api/requests.js';
+
 
 // Global state
 let browser: Browser | undefined;
@@ -57,6 +62,9 @@ let evaluateTool: EvaluateTool;
 let expectResponseTool: ExpectResponseTool;
 let assertResponseTool: AssertResponseTool;
 let customUserAgentTool: CustomUserAgentTool;
+let visibleTextTool: VisibleTextTool;
+let visibleHtmlTool: VisibleHtmlTool;
+
 let getRequestTool: GetRequestTool;
 let postRequestTool: PostRequestTool;
 let putRequestTool: PutRequestTool;
@@ -254,6 +262,8 @@ function initializeTools(server: any) {
   if (!expectResponseTool) expectResponseTool = new ExpectResponseTool(server);
   if (!assertResponseTool) assertResponseTool = new AssertResponseTool(server);
   if (!customUserAgentTool) customUserAgentTool = new CustomUserAgentTool(server);
+  if (!visibleTextTool) visibleTextTool = new VisibleTextTool(server);
+  if (!visibleHtmlTool) visibleHtmlTool = new VisibleHtmlTool(server);
   
   // API tools
   if (!getRequestTool) getRequestTool = new GetRequestTool(server);
@@ -403,6 +413,12 @@ export async function handleToolCall(
 
       case "playwright_custom_user_agent":
         return await customUserAgentTool.execute(args, context);
+        
+      case "playwright_visible_text":
+        return await visibleTextTool.execute(args, context);
+      
+      case "playwright_visible_html":
+        return await visibleHtmlTool.execute(args, context);
         
       // API tools
       case "playwright_get":

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -241,6 +241,25 @@ export function createToolDefinitions() {
         required: ["userAgent"],
       },
     },
+    ,
+    {
+      name: "playwright_get_visible_text",
+      description: "Get the visible text content of the current page",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: "playwright_get_html",
+      description: "Get the HTML content of the current page",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+      },
+    },
   ] as const satisfies Tool[];
 }
 
@@ -258,6 +277,8 @@ export const BROWSER_TOOLS = [
   "playwright_expect_response",
   "playwright_assert_response",
   "playwright_custom_user_agent",
+  "playwright_get_visible_text",
+  "playwright_get_html"
 ];
 
 // API Request tools for conditional launch

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -241,7 +241,6 @@ export function createToolDefinitions() {
         required: ["userAgent"],
       },
     },
-    ,
     {
       name: "playwright_get_visible_text",
       description: "Get the visible text content of the current page",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -251,7 +251,7 @@ export function createToolDefinitions() {
       },
     },
     {
-      name: "playwright_get_html",
+      name: "playwright_get_visible_html",
       description: "Get the HTML content of the current page",
       inputSchema: {
         type: "object",
@@ -277,7 +277,7 @@ export const BROWSER_TOOLS = [
   "playwright_assert_response",
   "playwright_custom_user_agent",
   "playwright_get_visible_text",
-  "playwright_get_html"
+  "playwright_get_visible_html"
 ];
 
 // API Request tools for conditional launch

--- a/src/tools/browser/visiblePage.ts
+++ b/src/tools/browser/visiblePage.ts
@@ -1,0 +1,93 @@
+import { resetBrowserState } from "../../toolHandler";
+import { ToolContext, ToolResponse, createErrorResponse, createSuccessResponse } from "../common/types";
+import { BrowserToolBase } from "./base";
+
+/**
+ * Tool for getting the visible text content of the current page
+ */
+export class VisibleTextTool extends BrowserToolBase {
+    /**
+     * Execute the visible text page tool
+     */
+    async execute(args: any, context: ToolContext): Promise<ToolResponse> {
+        // Check if browser is available
+      if (!context.browser || !context.browser.isConnected()) {
+        // If browser is not connected, we need to reset the state to force recreation
+        resetBrowserState();
+        return createErrorResponse(
+          "Browser is not connected. The connection has been reset - please retry your navigation."
+        );
+      }
+  
+      // Check if page is available and not closed
+      if (!context.page || context.page.isClosed()) {
+        return createErrorResponse(
+          "Page is not available or has been closed. Please retry your navigation."
+        );
+      }
+      return this.safeExecute(context, async (page) => {
+        try {
+            const visibleText = await page!.evaluate(() => {
+              const walker = document.createTreeWalker(
+                document.body,
+                NodeFilter.SHOW_TEXT,
+                {
+                  acceptNode: (node) => {
+                    const style = window.getComputedStyle(node.parentElement!);
+                    return (style.display !== "none" && style.visibility !== "hidden")
+                      ? NodeFilter.FILTER_ACCEPT
+                      : NodeFilter.FILTER_REJECT;
+                  },
+                }
+              );
+              let text = "";
+              let node;
+              while ((node = walker.nextNode())) {
+                const trimmedText = node.textContent?.trim();
+                if (trimmedText) {
+                  text += trimmedText + "\n";
+                }
+              }
+              return text.trim();
+            });
+            return createSuccessResponse(`Visible text content:\n${visibleText}`);
+        } catch (error) {
+            return createErrorResponse(`Failed to get visible text content: ${(error as Error).message}`);
+        }
+      });
+    }
+}
+
+/**
+ * Tool for getting the visible HTML content of the current page
+ */
+export class VisibleHtmlTool extends BrowserToolBase {
+    /**
+     * Execute the visible HTML page tool
+     */
+    async execute(args: any, context: ToolContext): Promise<ToolResponse> {
+        // Check if browser is available
+      if (!context.browser || !context.browser.isConnected()) {
+        // If browser is not connected, we need to reset the state to force recreation
+        resetBrowserState();
+        return createErrorResponse(
+          "Browser is not connected. The connection has been reset - please retry your navigation."
+        );
+      }
+  
+      // Check if page is available and not closed
+      if (!context.page || context.page.isClosed()) {
+        return createErrorResponse(
+          "Page is not available or has been closed. Please retry your navigation."
+        );
+      }
+      return this.safeExecute(context, async (page) => {
+        try {
+            const htmlContent = await page!.content();
+            return createSuccessResponse(`HTML content:\n${htmlContent}`);
+        } catch (error) {
+            return createErrorResponse(`Failed to get visible HTML content: ${(error as Error).message}`);
+        }
+      });
+    }
+}

--- a/src/tools/browser/visiblePage.ts
+++ b/src/tools/browser/visiblePage.ts
@@ -1,6 +1,6 @@
-import { resetBrowserState } from "../../toolHandler";
-import { ToolContext, ToolResponse, createErrorResponse, createSuccessResponse } from "../common/types";
-import { BrowserToolBase } from "./base";
+import { resetBrowserState } from "../../toolHandler.js";
+import { ToolContext, ToolResponse, createErrorResponse, createSuccessResponse } from "../common/types.js";
+import { BrowserToolBase } from "./base.js";
 
 /**
  * Tool for getting the visible text content of the current page

--- a/src/tools/browser/visiblePage.ts
+++ b/src/tools/browser/visiblePage.ts
@@ -6,88 +6,88 @@ import { BrowserToolBase } from "./base.js";
  * Tool for getting the visible text content of the current page
  */
 export class VisibleTextTool extends BrowserToolBase {
-    /**
-     * Execute the visible text page tool
-     */
-    async execute(args: any, context: ToolContext): Promise<ToolResponse> {
-        // Check if browser is available
-      if (!context.browser || !context.browser.isConnected()) {
-        // If browser is not connected, we need to reset the state to force recreation
-        resetBrowserState();
-        return createErrorResponse(
-          "Browser is not connected. The connection has been reset - please retry your navigation."
-        );
-      }
-  
-      // Check if page is available and not closed
-      if (!context.page || context.page.isClosed()) {
-        return createErrorResponse(
-          "Page is not available or has been closed. Please retry your navigation."
-        );
-      }
-      return this.safeExecute(context, async (page) => {
-        try {
-            const visibleText = await page!.evaluate(() => {
-              const walker = document.createTreeWalker(
-                document.body,
-                NodeFilter.SHOW_TEXT,
-                {
-                  acceptNode: (node) => {
-                    const style = window.getComputedStyle(node.parentElement!);
-                    return (style.display !== "none" && style.visibility !== "hidden")
-                      ? NodeFilter.FILTER_ACCEPT
-                      : NodeFilter.FILTER_REJECT;
-                  },
-                }
-              );
-              let text = "";
-              let node;
-              while ((node = walker.nextNode())) {
-                const trimmedText = node.textContent?.trim();
-                if (trimmedText) {
-                  text += trimmedText + "\n";
-                }
-              }
-              return text.trim();
-            });
-            return createSuccessResponse(`Visible text content:\n${visibleText}`);
-        } catch (error) {
-            return createErrorResponse(`Failed to get visible text content: ${(error as Error).message}`);
-        }
-      });
+  /**
+   * Execute the visible text page tool
+   */
+  async execute(args: any, context: ToolContext): Promise<ToolResponse> {
+    // Check if browser is available
+    if (!context.browser || !context.browser.isConnected()) {
+      // If browser is not connected, we need to reset the state to force recreation
+      resetBrowserState();
+      return createErrorResponse(
+        "Browser is not connected. The connection has been reset - please retry your navigation."
+      );
     }
+
+    // Check if page is available and not closed
+    if (!context.page || context.page.isClosed()) {
+      return createErrorResponse(
+        "Page is not available or has been closed. Please retry your navigation."
+      );
+    }
+    return this.safeExecute(context, async (page) => {
+      try {
+        const visibleText = await page!.evaluate(() => {
+          const walker = document.createTreeWalker(
+            document.body,
+            NodeFilter.SHOW_TEXT,
+            {
+              acceptNode: (node) => {
+                const style = window.getComputedStyle(node.parentElement!);
+                return (style.display !== "none" && style.visibility !== "hidden")
+                  ? NodeFilter.FILTER_ACCEPT
+                  : NodeFilter.FILTER_REJECT;
+              },
+            }
+          );
+          let text = "";
+          let node;
+          while ((node = walker.nextNode())) {
+            const trimmedText = node.textContent?.trim();
+            if (trimmedText) {
+              text += trimmedText + "\n";
+            }
+          }
+          return text.trim();
+        });
+        return createSuccessResponse(`Visible text content:\n${visibleText}`);
+      } catch (error) {
+        return createErrorResponse(`Failed to get visible text content: ${(error as Error).message}`);
+      }
+    });
+  }
 }
 
 /**
  * Tool for getting the visible HTML content of the current page
  */
 export class VisibleHtmlTool extends BrowserToolBase {
-    /**
-     * Execute the visible HTML page tool
-     */
-    async execute(args: any, context: ToolContext): Promise<ToolResponse> {
-        // Check if browser is available
-      if (!context.browser || !context.browser.isConnected()) {
-        // If browser is not connected, we need to reset the state to force recreation
-        resetBrowserState();
-        return createErrorResponse(
-          "Browser is not connected. The connection has been reset - please retry your navigation."
-        );
-      }
-  
-      // Check if page is available and not closed
-      if (!context.page || context.page.isClosed()) {
-        return createErrorResponse(
-          "Page is not available or has been closed. Please retry your navigation."
-        );
-      }
-      return this.safeExecute(context, async (page) => {
-        try {
-            const htmlContent = await page!.content();
-            return createSuccessResponse(`HTML content:\n${htmlContent}`);
-        } catch (error) {
-            return createErrorResponse(`Failed to get visible HTML content: ${(error as Error).message}`);
-        }
-      });
+  /**
+   * Execute the visible HTML page tool
+   */
+  async execute(args: any, context: ToolContext): Promise<ToolResponse> {
+    // Check if browser is available
+    if (!context.browser || !context.browser.isConnected()) {
+      // If browser is not connected, we need to reset the state to force recreation
+      resetBrowserState();
+      return createErrorResponse(
+        "Browser is not connected. The connection has been reset - please retry your navigation."
+      );
     }
+
+    // Check if page is available and not closed
+    if (!context.page || context.page.isClosed()) {
+      return createErrorResponse(
+        "Page is not available or has been closed. Please retry your navigation."
+      );
+    }
+    return this.safeExecute(context, async (page) => {
+      try {
+        const htmlContent = await page!.content();
+        return createSuccessResponse(`HTML content:\n${htmlContent}`);
+      } catch (error) {
+        return createErrorResponse(`Failed to get visible HTML content: ${(error as Error).message}`);
+      }
+    });
+  }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,7 +13,9 @@ export const BROWSER_TOOLS = [
   "playwright_hover",
   "playwright_evaluate",
   "playwright_console_logs",
-  "playwright_close"
+  "playwright_close",
+  "playwright_get_visible_text",
+  "playwright_get_html"
 ];
 
 export const API_TOOLS = [

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,7 +15,7 @@ export const BROWSER_TOOLS = [
   "playwright_console_logs",
   "playwright_close",
   "playwright_get_visible_text",
-  "playwright_get_html"
+  "playwright_get_visible_html"
 ];
 
 export const API_TOOLS = [


### PR DESCRIPTION
Add two functions to get the current page content either in plain text or html. So the Client is able to figure out the CSS selectors for further interactions by himsef.