### PR TITLE
Add MCP configuration file

### DIFF
--- a/mcp-config.json
+++ b/mcp-config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@executeautomation/playwright-mcp-server"]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a sample MCP configuration file (mcp-config.json) that can be used as a reference for setting up the Playwright MCP server with Claude Desktop or other MCP clients.

The configuration follows the example from the README and provides a ready-to-use reference for users.