### PR TITLE
docs: add installation instructions for Playwright MCP server in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ To install Playwright MCP for Claude Desktop automatically via [Smithery](https:
 ```bash
 npx -y @smithery/cli install @executeautomation/playwright-mcp-server --client claude
 ```
+#### Installation in VS Code
+
+Install the Playwright MCP server in VS Code using one of these buttons:
+
+<!--
+// Generate using?:
+const config = JSON.stringify({ name: 'playwright', command: 'npx', args: ["-y", "@executeautomation/playwright-mcp-server"] });
+const urlForWebsites = `vscode:mcp/install?${encodeURIComponent(config)}`;
+// Github markdown does not allow linking to `vscode:` directly, so you can use our redirect:
+const urlForGithub = `https://insiders.vscode.dev/redirect?url=${encodeURIComponent(urlForWebsites)}`;
+-->
+
+[<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522playwright%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540executeautomation%252Fplaywright-mcp-server%2522%255D%257D)
+
+Alternatively, you can install the Playwright MCP server using the VS Code CLI:
+
+```bash
+# For VS Code
+code --add-mcp '{"name":"playwright","command":"npx","args":["@executeautomation/playwright-mcp-server"]}'
+```
+
+```bash
+# For VS Code Insiders
+code-insiders --add-mcp '{"name":"playwright","command":"npx","args":["@executeautomation/playwright-mcp-server"]}'
+```
+
+After installation, the ExecuteAutomation Playwright MCP server will be available for use with your GitHub Copilot agent in VS Code.
+
 ## Configuration to use Playwright Server
 Here's the Claude Desktop configuration to use the Playwright server:
 


### PR DESCRIPTION
Update readme with playwright MCP installation in VSCode