### PR TITLE
allow filtering of html

### DIFF
--- a/docs/docs/playwright-web/Examples.md
+++ b/docs/docs/playwright-web/Examples.md
@@ -116,6 +116,26 @@ When I extract the HTML content of the page
 Then I should receive the complete HTML structure of the page
 ```
 
+You can also filter HTML content for easier analysis:
+
+```bdd
+Given I navigate to website "https://example.com/products"
+When I extract the HTML content of the page filtered to remove scripts and styles
+Then I should receive clean HTML without JavaScript or CSS code
+
+Given I navigate to website "https://example.com/products"
+When I extract the HTML content of the page filtered to remove meta tags
+Then I should receive HTML without metadata like charset, viewport, and SEO tags
+
+Given I navigate to website "https://example.com/products"
+When I extract the HTML content using the cleanHtml option
+Then I should receive a clean version of the HTML without scripts, styles, comments, and meta tags
+
+Given I navigate to website "https://example.com/products"
+When I extract only the HTML for the main product container using selector "#product-listings"
+Then I should receive just the HTML for the products section for easier analysis
+```
+
 Example use case for content analysis:
 
 ```bdd

--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -283,9 +283,25 @@ Get the visible text content of the current page.
 ### playwright_get_visible_html
 Get the HTML content of the current page.
 
+- **Inputs:**
+  - **`selector`** *(string, optional)*:  
+    CSS selector to limit the HTML to a specific container. If provided, only returns the HTML for that element.
+  - **`removeScripts`** *(boolean, optional, default: false)*:  
+    Remove all script tags from the HTML to reduce noise.
+  - **`removeComments`** *(boolean, optional, default: false)*:  
+    Remove all HTML comments to clean up the output.
+  - **`removeStyles`** *(boolean, optional, default: false)*:  
+    Remove all style tags from the HTML.
+  - **`removeMeta`** *(boolean, optional, default: false)*:  
+    Remove all meta tags from the HTML head section.
+  - **`minify`** *(boolean, optional, default: false)*:  
+    Minify the HTML output by removing extra whitespace.
+  - **`cleanHtml`** *(boolean, optional, default: false)*:  
+    Convenience option that combines removeScripts, removeComments, removeStyles, and removeMeta for a cleaner HTML output.
+
 - **Response:**
   - **`content`** *(string)*:  
-    The complete HTML content of the current page.
+    The HTML content of the current page, optionally filtered based on the provided parameters.
 
 ---
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -328,7 +328,15 @@ export function createToolDefinitions() {
       description: "Get the HTML content of the current page",
       inputSchema: {
         type: "object",
-        properties: {},
+        properties: {
+          selector: { type: "string", description: "CSS selector to limit the HTML to a specific container" },
+          removeScripts: { type: "boolean", description: "Remove all script tags from the HTML (default: false)" },
+          removeComments: { type: "boolean", description: "Remove all HTML comments (default: false)" },
+          removeStyles: { type: "boolean", description: "Remove all style tags from the HTML (default: false)" },
+          removeMeta: { type: "boolean", description: "Remove all meta tags from the HTML (default: false)" },
+          cleanHtml: { type: "boolean", description: "Perform comprehensive HTML cleaning (default: false)" },
+          minify: { type: "boolean", description: "Minify the HTML output (default: false)" }
+        },
         required: [],
       },
     },


### PR DESCRIPTION
The full html can add a lot of tokens to a chat context
This change set adds filtering prior to getting into the chat context
