### PR TITLE
feat: playwright_iframe_fill

### DIFF
--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -171,6 +171,17 @@ Click elements in an iframe on the page.
 
 ---
 
+### Playwright_iframe_fill
+Fill elements in an iframe on the page.
+
+- **`iframeSelector`** *(string)*:  
+  CSS selector for the iframe containing the element to fill.
+
+- **`selector`** *(string)*:  
+  CSS selector for the element to fill.
+
+---
+
 ### Playwright_hover
 Hover over elements on the page.
 

--- a/src/__tests__/toolHandler.test.ts
+++ b/src/__tests__/toolHandler.test.ts
@@ -15,12 +15,14 @@ jest.mock('playwright', () => {
   const mockOn = jest.fn();
   const mockIsClosed = jest.fn().mockReturnValue(false);
   
-  // Mock iframe click
+  // Mock iframe click and fill
   const mockIframeClick = jest.fn().mockImplementation(() => Promise.resolve());
+  const mockIframeFill = jest.fn().mockImplementation(() => Promise.resolve());
   const mockIframeLocator = jest.fn().mockReturnValue({
-    click: mockIframeClick
+    click: mockIframeClick,
+    fill: mockIframeFill
   });
-  
+
   // Mock locator
   const mockLocatorClick = jest.fn().mockImplementation(() => Promise.resolve());
   const mockLocatorFill = jest.fn().mockImplementation(() => Promise.resolve());

--- a/src/toolHandler.ts
+++ b/src/toolHandler.ts
@@ -25,7 +25,8 @@ import {
   FillTool,
   SelectTool,
   HoverTool,
-  EvaluateTool
+  EvaluateTool,
+  IframeFillTool
 } from './tools/browser/interaction.js';
 import { 
   VisibleTextTool, 
@@ -73,6 +74,7 @@ let closeBrowserTool: CloseBrowserTool;
 let consoleLogsTool: ConsoleLogsTool;
 let clickTool: ClickTool;
 let iframeClickTool: IframeClickTool;
+let iframeFillTool: IframeFillTool;
 let fillTool: FillTool;
 let selectTool: SelectTool;
 let hoverTool: HoverTool;
@@ -310,6 +312,7 @@ function initializeTools(server: any) {
   if (!consoleLogsTool) consoleLogsTool = new ConsoleLogsTool(server);
   if (!clickTool) clickTool = new ClickTool(server);
   if (!iframeClickTool) iframeClickTool = new IframeClickTool(server);
+  if (!iframeFillTool) iframeFillTool = new IframeFillTool(server);
   if (!fillTool) fillTool = new FillTool(server);
   if (!selectTool) selectTool = new SelectTool(server);
   if (!hoverTool) hoverTool = new HoverTool(server);
@@ -474,6 +477,9 @@ export async function handleToolCall(
         
       case "playwright_iframe_click":
         return await iframeClickTool.execute(args, context);
+
+      case "playwright_iframe_fill":
+        return await iframeFillTool.execute(args, context);
         
       case "playwright_fill":
         return await fillTool.execute(args, context);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -134,6 +134,19 @@ export function createToolDefinitions() {
       },
     },
     {
+      name: "playwright_iframe_fill",
+      description: "Fill an element in an iframe on the page",
+      inputSchema: {
+        type: "object",
+        properties: {
+          iframeSelector: { type: "string", description: "CSS selector for the iframe containing the element to fill" },
+          selector: { type: "string", description: "CSS selector for the element to fill" },
+          value: { type: "string", description: "Value to fill" },
+        },
+        required: ["iframeSelector", "selector", "value"],
+      },
+    },
+    {
       name: "playwright_fill",
       description: "fill out an input field",
       inputSchema: {
@@ -418,6 +431,7 @@ export const BROWSER_TOOLS = [
   "playwright_screenshot",
   "playwright_click",
   "playwright_iframe_click",
+  "playwright_iframe_fill",
   "playwright_fill",
   "playwright_select",
   "playwright_hover",

--- a/src/tools/browser/interaction.ts
+++ b/src/tools/browser/interaction.ts
@@ -66,6 +66,26 @@ export class IframeClickTool extends BrowserToolBase {
 }
 
 /**
+ * Tool for filling elements inside iframes
+ */
+export class IframeFillTool extends BrowserToolBase {
+  /**
+   * Execute the iframe fill tool
+   */
+  async execute(args: any, context: ToolContext): Promise<ToolResponse> {
+    return this.safeExecute(context, async (page) => {
+      const frame = page.frameLocator(args.iframeSelector);
+      if (!frame) {
+        return createErrorResponse(`Iframe not found: ${args.iframeSelector}`);
+      }
+      
+      await frame.locator(args.selector).fill(args.value);
+      return createSuccessResponse(`Filled element ${args.selector} inside iframe ${args.iframeSelector} with: ${args.value}`);
+    });
+  }
+}
+
+/**
  * Tool for filling form fields
  */
 export class FillTool extends BrowserToolBase {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ export const BROWSER_TOOLS = [
   "playwright_screenshot",
   "playwright_click",
   "playwright_iframe_click",
+  "playwright_iframe_fill",
   "playwright_fill",
   "playwright_select",
   "playwright_hover",


### PR DESCRIPTION
Hi master!
Just as @VinceOPS added the functionality to click items inside iframes in his PR I wanted to add the option to also fill the elements, as now I am using the tool from my VS Code and it's struggling while filling the elements using playwright_fill.

I have followed the same approach as is direct and simple to understand. Here is an example testing it in my local:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/8051d07e-d2e6-4175-90d6-d2c2e3d87986" />
And it worked!
<img width="307" alt="image" src="https://github.com/user-attachments/assets/f19a4cbe-1726-4a15-bd8b-2a6ed630fb7a" />
Thanks for the amazing tool and happy to contribute!!
