### PR TITLE
docs: Remove npx usage instructions from HTTP/SSE Transport guide

### DIFF
--- a/docs/docs/playwright-web/HTTP-SSE-Transport.mdx
+++ b/docs/docs/playwright-web/HTTP-SSE-Transport.mdx
@@ -30,14 +30,6 @@ The HTTP/SSE transport allows the MCP server to run as a standalone HTTP server,
 
 ## Quick Start
 
-### Starting the HTTP Server
-
-#### Recommended: Using npx (Version 1.0.9+)
-
-```bash
-npx @executeautomation/playwright-mcp-server --port 8931
-```
-
 :::info Version Requirement
 **npx support requires version 1.0.9 or later.** If you're using an older version, you'll need to use global installation (see below).
 :::

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,8 @@ HTTP MODE CONFIGURATION:
   {
     "mcpServers": {
       "playwright": {
-        "url": "http://localhost:8931/mcp"
+        "url": "http://localhost:8931/mcp",
+        "type": "http"
       }
     }
   }


### PR DESCRIPTION
feat: Add type field to HTTP mode configuration in server setup